### PR TITLE
Make deployment configurable via env vars for PaaS hosting

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,67 @@
+# Despliegue (acceso desde fuera)
+
+El proyecto tiene 3 piezas: **frontend** (React), **backend** (FastAPI) y **MongoDB**.
+La configuración ya no está hardcodeada: las URLs se inyectan por variables de entorno,
+así que se puede desplegar en cualquier PaaS.
+
+Variables clave:
+
+| Servicio | Variable | Para qué sirve |
+|----------|----------|----------------|
+| backend  | `MONGO_URI` | URI de conexión a MongoDB |
+| backend  | `CORS_ORIGINS` | Origen(es) permitidos. La URL pública del frontend, o `*` para abrir a todos |
+| frontend | `REACT_APP_API_BASE_URL` | URL pública del backend (se hornea en el build) |
+
+> ⚠️ `REACT_APP_API_BASE_URL` se usa **en tiempo de build**. Si la cambias, hay que
+> reconstruir el frontend.
+
+---
+
+## Opción A — Railway (recomendada, MongoDB persistente incluido)
+
+1. Entra en https://railway.app y crea un proyecto desde el repo de GitHub.
+2. **Añade MongoDB**: botón *New → Database → Add MongoDB*. Railway crea la base de
+   datos con un **volumen persistente** y expone la variable `MONGO_URL`.
+3. **Servicio backend**:
+   - *New → GitHub Repo*, raíz `/backend` (Root Directory = `backend`).
+   - Variables:
+     - `MONGO_URI` = referencia a `${{MongoDB.MONGO_URL}}`
+     - `CORS_ORIGINS` = `*` (o luego la URL exacta del frontend)
+   - Railway detecta el `Dockerfile` y asigna `PORT` automáticamente.
+   - Activa *Generate Domain* para obtener la URL pública (ej. `https://backend-xxx.up.railway.app`).
+4. **Servicio frontend**:
+   - *New → GitHub Repo*, Root Directory = `frontend`.
+   - Variable: `REACT_APP_API_BASE_URL` = la URL pública del backend del paso anterior.
+   - *Generate Domain* para obtener la URL pública del frontend.
+5. (Opcional pero recomendado) Vuelve al backend y pon `CORS_ORIGINS` = la URL pública
+   del frontend para no dejar el CORS abierto.
+
+Listo: abre la URL del frontend desde cualquier sitio.
+
+---
+
+## Opción B — Render
+
+Render no gestiona MongoDB, así que usa **MongoDB Atlas** (free tier) para los datos:
+
+1. Crea un cluster gratis en https://www.mongodb.com/atlas y copia su connection string.
+2. En https://render.com crea dos *Web Services* desde el repo (runtime = Docker):
+   - **backend**: Root Directory `backend`. Env:
+     - `MONGO_URI` = connection string de Atlas
+     - `CORS_ORIGINS` = URL pública del frontend (o `*`)
+   - **frontend**: Root Directory `frontend`. Env (marcar como *available at build time*):
+     - `REACT_APP_API_BASE_URL` = URL pública del backend
+3. Render asigna `PORT` automáticamente; los Dockerfiles ya lo respetan.
+
+---
+
+## Local (Docker Compose)
+
+Para probar en tu máquina, sigue funcionando igual y ahora Mongo **persiste** los datos:
+
+```bash
+docker compose up -d --build
+```
+
+- Frontend: http://localhost:3000
+- Backend:  http://localhost:8000/docs

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,4 +23,5 @@ RUN mkdir -p uploads
 # Asegurarse de que el directorio tenga los permisos correctos
 RUN chmod 777 uploads
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Usa el puerto que asigne la plataforma ($PORT) o 8000 en local.
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,17 @@
-FRONTEND_URL = "http://localhost:3000"
-MONGO_URI = "mongodb://mongo:27017"
-SWH_API_URL = "http://example.com/swh-api"
-SWH_API_USERNAME = "username"
-SWH_API_PASSWORD = "password"
-DATA_COLLECTION_INTERVAL = 300  # Intervalo de recopilación de datos en segundos
+import os
+
+# URL(s) del frontend permitidas por CORS. Acepta una lista separada por comas.
+# Usa "*" para permitir cualquier origen (suficiente para una demo pública).
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+CORS_ORIGINS = os.getenv("CORS_ORIGINS", FRONTEND_URL)
+
+# Conexión a MongoDB. En la nube se inyecta la URI del Mongo gestionado.
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://mongo:27017")
+
+# Integración SWH
+SWH_API_URL = os.getenv("SWH_API_URL", "http://example.com/swh-api")
+SWH_API_USERNAME = os.getenv("SWH_API_USERNAME", "username")
+SWH_API_PASSWORD = os.getenv("SWH_API_PASSWORD", "password")
+
+# Intervalo de recopilación de datos en segundos
+DATA_COLLECTION_INTERVAL = int(os.getenv("DATA_COLLECTION_INTERVAL", "300"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from config import FRONTEND_URL
+from config import CORS_ORIGINS
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -19,10 +19,13 @@ logger = logging.getLogger("pymongo").setLevel(logging.WARNING)
 
 app = FastAPI()
 
+allowed_origins = [origin.strip() for origin in CORS_ORIGINS.split(",") if origin.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[FRONTEND_URL],
-    allow_credentials=True,
+    allow_origins=allowed_origins,
+    # allow_credentials debe ser False cuando se permite cualquier origen ("*").
+    allow_credentials="*" not in allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: always
     ports:
       - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
   frontend:
     build:
       context: ./frontend
@@ -28,3 +30,6 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+
+volumes:
+  mongo_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,27 @@
-# Usa una imagen base de Node.js
-FROM node:14
+# ---- Build stage ----
+FROM node:18-alpine AS build
 
 WORKDIR /app
 
 COPY package*.json ./
 RUN npm install
 
-COPY . .
+# URL del backend, inyectada en el bundle en tiempo de build.
+# Railway/Render pasan las variables del servicio como build args.
+ARG REACT_APP_API_BASE_URL
+ENV REACT_APP_API_BASE_URL=$REACT_APP_API_BASE_URL
 
-CMD ["npm", "run", "start"]
+COPY . .
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM node:18-alpine
+
+WORKDIR /app
+RUN npm install -g serve
+
+COPY --from=build /app/build ./build
+
+# Sirve el build estático en el puerto que asigne la plataforma ($PORT) o 3000.
+ENV PORT=3000
+CMD ["sh", "-c", "serve -s build -l ${PORT:-3000}"]

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,3 +1,6 @@
 // config.js
-export const API_BASE_URL = 'http://localhost:8000';
-export const UPLOADS_BASE_URL = 'http://localhost:8000/uploads';
+// La URL del backend se inyecta en tiempo de build con REACT_APP_API_BASE_URL.
+// En desarrollo local cae por defecto a localhost:8000.
+export const API_BASE_URL =
+  process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+export const UPLOADS_BASE_URL = `${API_BASE_URL}/uploads`;


### PR DESCRIPTION
## Resumen

Prepara el proyecto para desplegarlo en un PaaS (Railway/Render) y acceder desde fuera. El bloqueador principal era que el frontend llamaba al backend en `http://localhost:8000` hardcodeado, lo que rompe cualquier acceso externo. Ahora toda la configuración se inyecta por variables de entorno.

## Cambios

- **Frontend (`src/config.js`)**: la URL del backend se lee de `REACT_APP_API_BASE_URL` (con fallback a localhost para desarrollo).
- **Frontend (`Dockerfile`)**: build de producción multi-stage que sirve el estático con `serve` y respeta el `$PORT` que asigna la plataforma.
- **Backend (`config.py` / `main.py`)**: `MONGO_URI`, `FRONTEND_URL`/`CORS_ORIGINS` y credenciales SWH desde el entorno; CORS admite lista de orígenes separada por comas o `*`.
- **Backend (`Dockerfile`)**: respeta el `$PORT` de la plataforma.
- **`docker-compose.yml`**: volumen persistente `mongo_data` para que los datos de MongoDB sobrevivan a reinicios en local.
- **`DEPLOY.md`**: guía de despliegue paso a paso para Railway (recomendado, con MongoDB gestionado persistente) y Render (con MongoDB Atlas).

## Variables de entorno

| Servicio | Variable | Para qué |
|----------|----------|----------|
| backend  | `MONGO_URI` | URI de MongoDB |
| backend  | `CORS_ORIGINS` | Orígenes permitidos (URL del frontend o `*`) |
| frontend | `REACT_APP_API_BASE_URL` | URL pública del backend (en tiempo de build) |

## Notas

- `REACT_APP_API_BASE_URL` se hornea en el build del frontend: si cambia, hay que reconstruir.
- Sin cambios funcionales en la lógica de la aplicación; los valores por defecto mantienen el flujo de desarrollo local intacto.

https://claude.ai/code/session_01TLJUtqJYUBFCunQFtrFonS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLJUtqJYUBFCunQFtrFonS)_